### PR TITLE
Tidy up some typos throughout

### DIFF
--- a/addons/wfc/examples/assets/kenny-nature-kit/library-source.tscn
+++ b/addons/wfc/examples/assets/kenny-nature-kit/library-source.tscn
@@ -32,7 +32,7 @@
 
 [node name="library-source" type="Node3D"]
 
-[node name="MeshInstance3D" type="MeshInstance3D" parent="."]
+[node name="GroundGrass" type="MeshInstance3D" parent="."]
 mesh = ExtResource("1_825gh")
 
 [node name="GroundPathBend" type="MeshInstance3D" parent="."]

--- a/addons/wfc/problems/2d/rules_2d.gd
+++ b/addons/wfc/problems/2d/rules_2d.gd
@@ -90,7 +90,7 @@ const MAX_INT_32 = 2147483647
 
 func get_influence_range() -> Vector2i:
 	"""
-	Returns distances along X and Y axes at wiich a certain cell stops
+	Returns distances along X and Y axes at which a certain cell stops
 	influencing domains of other cells along those axes.
 
 	Returned value will be equal to maximum allowed integer value if constraints
@@ -138,21 +138,3 @@ func get_influence_range() -> Vector2i:
 		res.y = max(res.y, abs(axis.y) * longest_path)
 
 	return res
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/addons/wfc/solver/solver.gd
+++ b/addons/wfc/solver/solver.gd
@@ -80,7 +80,7 @@ func _propagate_constraints() -> bool:
 func solve_step() -> bool:
 	"""
 	Returns:
-		true iff process has termitated (eighter successfully or with failure)
+		true iff process has termitated (either successfully or with failure)
 	"""
 	assert(current_state != null)
 

--- a/addons/wfc/utils/bitmatrix.gd
+++ b/addons/wfc/utils/bitmatrix.gd
@@ -89,7 +89,7 @@ func format_bits() -> String:
 
 func get_longest_path() -> int:
 	"""
-	For an NxN bit-matrix, replresenting links in a direct graph of N nodes,
+	For an NxN bit-matrix, representing links in a direct graph of N nodes,
 	returns the length of the longest path that is a shortest path between
 	certain two nodes.
 	


### PR DESCRIPTION
In reading the code I found several typos (and a few extra newlines). Cleaned them up.

One of the meshes in the GridMap example still had its default name, I renamed it GroundGrass, but I did not yet regenerate the mesh library.